### PR TITLE
SF-1370: Support matchPrefix autocomplete parameter

### DIFF
--- a/src/core/sayt.ts
+++ b/src/core/sayt.ts
@@ -99,6 +99,7 @@ export interface AutocompleteConfig {
   numNavigations?: number;
   sortAlphabetically?: boolean;
   fuzzyMatch?: boolean;
+  matchPrefix?: boolean;
 }
 
 export interface ProductSearchConfig {

--- a/src/core/sayt.ts
+++ b/src/core/sayt.ts
@@ -28,15 +28,25 @@ export class Sayt {
   autocomplete(query: string = '', config?: QueryTimeAutocompleteConfig, cb?: SearchCallback): Promise<AutocompleteResponse> {
     const finalConfig: QueryTimeAutocompleteConfig =
       Object.assign({ collection: this.config.collection }, this.config.autocomplete, config);
+    const {
+      sortAlphabetically: alphabetize,
+      collection,
+      fuzzyMatch: fuzzy,
+      language,
+      numNavigations: navigationItems,
+      numSearchTerms: searchItems,
+      ...rest
+    } = finalConfig;
     const response = jsonp(this.url, {
-      alphabetize: finalConfig.sortAlphabetically,
-      collection: finalConfig.collection,
-      fuzzy: finalConfig.fuzzyMatch,
+      alphabetize,
+      collection,
+      fuzzy,
       query,
-      language: finalConfig.language,
-      navigationItems: finalConfig.numNavigations,
+      language,
+      navigationItems,
       productItems: 0,
-      searchItems: finalConfig.numSearchTerms,
+      searchItems,
+      ...rest
     });
 
     return this.callbackOrPromise(response, cb);

--- a/test/unit/sayt.ts
+++ b/test/unit/sayt.ts
@@ -1,4 +1,4 @@
-import { Sayt } from '../../src/core/sayt';
+import { Sayt, SaytConfig, QueryTimeAutocompleteConfig } from '../../src/core/sayt';
 import utils = require('../../src/core/utils');
 import { expect } from 'chai';
 
@@ -41,11 +41,12 @@ describe('SAYT', () => {
     });
 
     it('should configure query', (done) => {
-      sayt.configure({
+      sayt.configure(<SaytConfig>{
         autocomplete: {
           numSearchTerms: 4,
           sortAlphabetically: true,
           language: 'en',
+          a: 'b',
         },
       });
       utils.jsonp = (url, body) => {
@@ -53,6 +54,7 @@ describe('SAYT', () => {
         expect(body.navigationItems).to.eq(5);
         expect(body.alphabetize).to.be.true;
         expect(body.language).to.eq('en');
+        expect(body.a).to.eq('b');
         return Promise.resolve();
       };
 
@@ -65,10 +67,11 @@ describe('SAYT', () => {
       utils.jsonp = (url, body) => {
         expect(body.searchItems).to.eq(8);
         expect(body.navigationItems).to.eq(2);
+        expect(body.a).to.eq('b');
         return Promise.resolve();
       };
 
-      sayt.autocomplete('skirts', { numSearchTerms: 8, numNavigations: 2 })
+      sayt.autocomplete('skirts', <QueryTimeAutocompleteConfig>{ numSearchTerms: 8, numNavigations: 2, a: 'b' })
         .then(() => done());
     });
   });


### PR DESCRIPTION
More generally, this change allows any unknown configuration option to be passed through for forward-compatibility.